### PR TITLE
fix(logger): clear progress timeout handle to prevent exit delay

### DIFF
--- a/src/modules/logger.ts
+++ b/src/modules/logger.ts
@@ -198,6 +198,7 @@ export class Logger {
 export class ProgressIndicator {
   private interval?: NodeJS.Timeout | undefined;
   private timeoutId?: NodeJS.Timeout | undefined;
+  private maxTimeoutId?: NodeJS.Timeout | undefined;
   private frame = 0;
   private readonly frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   private startTime: number;
@@ -222,7 +223,7 @@ export class ProgressIndicator {
       }, this.minDuration);
 
       // Auto-timeout after maxDuration
-      setTimeout(() => {
+      this.maxTimeoutId = setTimeout(() => {
         if (this.interval) {
           this.fail('Operation timed out');
         }
@@ -275,6 +276,10 @@ export class ProgressIndicator {
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);
       this.timeoutId = undefined;
+    }
+    if (this.maxTimeoutId) {
+      clearTimeout(this.maxTimeoutId);
+      this.maxTimeoutId = undefined;
     }
     this.isActive = false;
   }

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,27 @@
+import { ProgressIndicator } from '../../src/modules/logger.js';
+
+describe('ProgressIndicator', () => {
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('should clear all timers on succeed to avoid hanging process exit', () => {
+    const indicator = new ProgressIndicator('Analyzing changes', false);
+
+    // One delayed spinner timer + one max duration timeout timer.
+    expect(jest.getTimerCount()).toBe(2);
+
+    indicator.succeed('Done');
+
+    // Regression check: no pending timeout handles should remain.
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary:
Clear the max-duration timer handle in ProgressIndicator after push completes. Previously, completed runs would leave pending timeout handles alive, causing unnecessary delays during process exit. This fix ensures the timer is tracked and properly cleaned up when the progress indicator finishes.

Testing:
- Verified that the process exits promptly after successful push completes
- Confirmed timeout handles are cleared when progress indicator reaches completion state